### PR TITLE
유저 엔티티 생성

### DIFF
--- a/src/main/java/com/hcu/hot6/domain/Department.java
+++ b/src/main/java/com/hcu/hot6/domain/Department.java
@@ -1,0 +1,45 @@
+package com.hcu.hot6.domain;
+
+public enum Department {
+    // 글로벌리더십학부
+    GLS,
+
+    // 국제어문학부
+    INT_STUDY,
+
+    // 경영경제학부
+    MANAGEMENT,
+
+    // 법학부
+    LAW,
+
+    // 커뮤니케이션학부
+    COMMUNICATION,
+
+    // 상담심리사회복지학부
+    COUNSELING,
+
+    // 생명과학부
+    LIFE_SCIENCE,
+
+    // 공간환경시스템공학부
+    SPATIAL_ENV,
+
+    // 전산전자공학부
+    CSEE,
+
+    // 콘텐츠융합디자인학부
+    CCD,
+
+    // 기계제어공학부
+    MCE,
+
+    // ICT 창업학부
+    ICT,
+
+    // 창의융합교육원
+    CCE,
+
+    // AI 융합교육원
+    AI
+}

--- a/src/main/java/com/hcu/hot6/domain/Member.java
+++ b/src/main/java/com/hcu/hot6/domain/Member.java
@@ -1,0 +1,41 @@
+package com.hcu.hot6.domain;
+
+import jakarta.persistence.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    @Column(nullable = false)
+    private boolean isPublic;
+
+    @Enumerated(value = EnumType.STRING)
+    private Department department;
+
+    @Enumerated(value = EnumType.STRING)
+    private Position position;
+
+    private String bio;
+    private int grade;
+    private String club;
+    private String contact;
+    private String externalLinks;
+
+    @ManyToMany(mappedBy = "likes")
+    private List<Post> likes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "author")
+    private List<Post> posts = new ArrayList<>();
+}

--- a/src/main/java/com/hcu/hot6/domain/Position.java
+++ b/src/main/java/com/hcu/hot6/domain/Position.java
@@ -1,0 +1,12 @@
+package com.hcu.hot6.domain;
+
+public enum Position {
+    /**
+     * 기획자
+     * 디자이너
+     * 개발자
+     */
+    PLANNER,
+    DESIGNER,
+    DEVELOPER
+}


### PR DESCRIPTION
- [x] 예약어(User) 사용을 피하기 위해 엔티티명을 User -> Member 변경
- [x] 학부, 포지션에 대한 enum type 생성

## 학부(14)
- 글로벌리더십학부
- 국제어문학부
- 경영경제학부
- 법학부
- 커뮤니케이션학부
- 상담심리사회복지학부
- 생명과학부
- 공간환경시스템공학부
- 전산전자공학부
- 콘텐츠융합디자인학부
- 기계제어공학부
- ICT 창업학부
- 창의융합교육원
- AI 융합교육원

## 포지션
- 기획자
- 디자이너
- 개발자

resolved: #2