### PR TITLE
유저 프로필 생성/조회 및 CORS 정책 수정

### DIFF
--- a/src/main/java/com/hcu/hot6/controller/MemberController.java
+++ b/src/main/java/com/hcu/hot6/controller/MemberController.java
@@ -1,0 +1,29 @@
+package com.hcu.hot6.controller;
+
+import com.hcu.hot6.domain.request.MemberRequest;
+import com.hcu.hot6.domain.response.MemberResponse;
+import com.hcu.hot6.service.MemberService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Controller
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping("/users")
+    public ResponseEntity<MemberResponse> registerMember(@AuthenticationPrincipal OAuth2User user,
+                                                         @RequestBody @Valid MemberRequest form) {
+        String email = user.getName();
+        MemberResponse response = memberService.updateMember(email, form);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/hcu/hot6/controller/MemberController.java
+++ b/src/main/java/com/hcu/hot6/controller/MemberController.java
@@ -1,7 +1,10 @@
 package com.hcu.hot6.controller;
 
+import com.hcu.hot6.domain.Member;
 import com.hcu.hot6.domain.request.MemberRequest;
+import com.hcu.hot6.domain.response.MemberProfileResponse;
 import com.hcu.hot6.domain.response.MemberResponse;
+import com.hcu.hot6.repository.MemberRepository;
 import com.hcu.hot6.service.MemberService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -9,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -18,6 +22,8 @@ public class MemberController {
 
     private final MemberService memberService;
 
+    private final MemberRepository memberRepository;
+
     @PostMapping("/users")
     public ResponseEntity<MemberResponse> registerMember(@AuthenticationPrincipal OAuth2User user,
                                                          @RequestBody @Valid MemberRequest form) {
@@ -25,5 +31,13 @@ public class MemberController {
         MemberResponse response = memberService.updateMember(email, form);
 
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/users/me")
+    public ResponseEntity<MemberProfileResponse> getProfile(@AuthenticationPrincipal OAuth2User user) {
+        Member member = memberRepository.findByEmail(user.getName())
+                .orElseThrow();
+
+        return ResponseEntity.ok(new MemberProfileResponse(member));
     }
 }

--- a/src/main/java/com/hcu/hot6/domain/Department.java
+++ b/src/main/java/com/hcu/hot6/domain/Department.java
@@ -1,6 +1,8 @@
 package com.hcu.hot6.domain;
 
 public enum Department {
+    NONE,
+
     // 글로벌리더십학부
     GLS,
 

--- a/src/main/java/com/hcu/hot6/domain/Member.java
+++ b/src/main/java/com/hcu/hot6/domain/Member.java
@@ -1,12 +1,13 @@
 package com.hcu.hot6.domain;
 
+import com.hcu.hot6.domain.request.MemberRequest;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import net.minidev.json.annotate.JsonIgnore;
-import org.jetbrains.annotations.NotNull;
 import org.springframework.util.Assert;
 
 import java.util.ArrayList;
@@ -83,5 +84,19 @@ public class Member {
         this.uid = uid;
         this.email = email;
         this.pictureUrl = pictureUrl;
+    }
+
+    public void update(MemberRequest form) {
+        this.nickname = form.getNickname();
+        this.isPublic = form.getIsPublic();
+
+        this.department = form.getDepartment();
+        this.position = form.getPosition();
+        this.bio = form.getBio();
+        this.grade = form.getGrade();
+        this.contact = form.getContact();
+        this.club = String.join(",", form.getClub());
+        this.externalLinks = String.join(",", form.getExternalLinks());
+
     }
 }

--- a/src/main/java/com/hcu/hot6/domain/Member.java
+++ b/src/main/java/com/hcu/hot6/domain/Member.java
@@ -8,7 +8,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import net.minidev.json.annotate.JsonIgnore;
-import org.springframework.util.Assert;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -56,21 +55,20 @@ public class Member {
 
     //=== 생성 메서드 ===//
     @Builder(builderClassName = "ByMemberBuilder", builderMethodName = "ByMemberBuilder")
-    public Member(String email, String nickname, boolean isPublic, Department department, Position position, String bio, int grade, String club, String contact, String externalLinks) {
-        Assert.hasText(email, "유저의 소셜로그인이메일(email)은 필수 입력사항입니다.");
-        Assert.hasText(nickname, "유저의 닉네임(nickname)은 필수 입력사항입니다.");
-        Assert.notNull(isPublic, "유저의 인재풀공개여부(isPublic)은 필수 입력사항입니다.");
-
+    public Member(String email, String pictureUrl, Department department, Position position, boolean isPublic, String nickname, String bio, Integer grade, String club, String contact, String externalLinks, List<Post> likes, List<Post> posts) {
         this.email = email;
-        this.nickname = nickname;
-        this.isPublic = isPublic;
+        this.pictureUrl = pictureUrl;
         this.department = department;
         this.position = position;
+        this.isPublic = isPublic;
+        this.nickname = nickname;
         this.bio = bio;
         this.grade = grade;
         this.club = club;
         this.contact = contact;
         this.externalLinks = externalLinks;
+        this.likes = likes;
+        this.posts = posts;
     }
 
     public Member(Map<String, Object> attributes) {

--- a/src/main/java/com/hcu/hot6/domain/Position.java
+++ b/src/main/java/com/hcu/hot6/domain/Position.java
@@ -6,6 +6,7 @@ public enum Position {
      * 디자이너
      * 개발자
      */
+    NONE,
     PLANNER,
     DESIGNER,
     DEVELOPER

--- a/src/main/java/com/hcu/hot6/domain/Post.java
+++ b/src/main/java/com/hcu/hot6/domain/Post.java
@@ -2,6 +2,7 @@ package com.hcu.hot6.domain;
 
 import com.hcu.hot6.domain.request.PostCreationRequest;
 import com.hcu.hot6.domain.request.PostUpdateRequest;
+import com.hcu.hot6.domain.response.PostReadOneResponse;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -10,6 +11,7 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import net.minidev.json.annotate.JsonIgnore;
 import org.jetbrains.annotations.NotNull;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -100,5 +102,9 @@ public abstract class Post {
         this.total = total;
         this.currTotal = currTotal;
         this.isCompleted = total == currTotal;
+    }
+
+    public PostReadOneResponse toResponse() {
+        return new PostReadOneResponse(this);
     }
 }

--- a/src/main/java/com/hcu/hot6/domain/request/MemberRequest.java
+++ b/src/main/java/com/hcu/hot6/domain/request/MemberRequest.java
@@ -1,0 +1,31 @@
+package com.hcu.hot6.domain.request;
+
+import com.hcu.hot6.domain.Department;
+import com.hcu.hot6.domain.Position;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Builder
+@Getter
+public class MemberRequest {
+    @NotNull
+    private final String nickname;
+
+    @NotNull
+    private final Boolean isPublic;
+
+    private final String bio;
+    private final Department department = Department.NONE;
+    private final Position position = Position.NONE;
+    private final Integer grade;
+    private final String contact;
+    private final List<String> club = new ArrayList<>();
+    private final List<String> externalLinks = new ArrayList<>();
+
+}

--- a/src/main/java/com/hcu/hot6/domain/response/MemberProfileResponse.java
+++ b/src/main/java/com/hcu/hot6/domain/response/MemberProfileResponse.java
@@ -1,0 +1,55 @@
+package com.hcu.hot6.domain.response;
+
+import com.hcu.hot6.domain.Department;
+import com.hcu.hot6.domain.Member;
+import com.hcu.hot6.domain.Position;
+import com.hcu.hot6.domain.Post;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Getter
+public class MemberProfileResponse {
+
+    public MemberProfileResponse(Member member) {
+        this.email = member.getEmail();
+        this.pictureUrl = member.getPictureUrl();
+        this.nickname = member.getNickname();
+        this.isPublic = member.isPublic();
+        this.department = member.getDepartment();
+        this.position = member.getPosition();
+        this.bio = member.getBio();
+        this.grade = member.getGrade();
+        this.contact = member.getContact();
+
+        this.club = Arrays.asList(member.getClub().split(","));
+        this.externalLinks = Arrays.asList(member.getExternalLinks().split(","));
+
+        this.likes = member.getLikes()
+                .stream()
+                .map(Post::toResponse)
+                .collect(Collectors.toList());
+        this.posts = member.getPosts()
+                .stream()
+                .map(Post::toResponse)
+                .collect(Collectors.toList());
+    }
+
+    private final String email;
+    private final String pictureUrl;
+    private final String nickname;
+    private final Boolean isPublic;
+    private final Department department;
+    private final Position position;
+    private final String bio;
+    private final Integer grade;
+    private final String contact;
+    private final List<String> club;
+    private final List<String> externalLinks;
+    private final List<PostReadOneResponse> likes;
+    private final List<PostReadOneResponse> posts;
+}

--- a/src/main/java/com/hcu/hot6/domain/response/MemberResponse.java
+++ b/src/main/java/com/hcu/hot6/domain/response/MemberResponse.java
@@ -1,0 +1,23 @@
+package com.hcu.hot6.domain.response;
+
+import com.hcu.hot6.domain.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MemberResponse {
+
+    @Builder
+    public MemberResponse(String nickname, Boolean isPublic) {
+        this.nickname = nickname;
+        this.isPublic = isPublic;
+    }
+
+    public MemberResponse(Member member) {
+        this.nickname = member.getNickname();
+        this.isPublic = member.isPublic();
+    }
+
+    private final String nickname;
+    private final Boolean isPublic;
+}

--- a/src/main/java/com/hcu/hot6/domain/response/PostReadOneResponse.java
+++ b/src/main/java/com/hcu/hot6/domain/response/PostReadOneResponse.java
@@ -1,5 +1,9 @@
 package com.hcu.hot6.domain.response;
 
+import com.hcu.hot6.domain.Mentoring;
+import com.hcu.hot6.domain.Post;
+import com.hcu.hot6.domain.Project;
+import com.hcu.hot6.domain.Study;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -37,6 +41,48 @@ public class PostReadOneResponse {
     private int currMentor;
     private int currMentee;
     private boolean hasPay;
+
+    public PostReadOneResponse(Post post) {
+        this.dtype = post.getDtype();
+        this.id = post.getId();
+        this.title = post.getTitle();
+        this.content = post.getContent();
+        this.contact = post.getContact();
+        this.writer = post.getAuthor().getNickname();
+        this.postStart = post.getPeriod().getPostStart();
+        this.postEnd = post.getPeriod().getPostEnd();
+        this.projectStart = post.getPeriod().getProjectStart();
+        this.projectEnd = post.getPeriod().getProjectEnd();
+
+        switch (dtype) {
+            case "P" -> {
+                Project project = (Project) post;
+
+                this.maxDesigner = project.getMaxDesigner();
+                this.maxDeveloper = project.getMaxDeveloper();
+                this.maxPlanner = project.getMaxPlanner();
+
+                this.currDesigner = project.getCurrDesigner();
+                this.currDeveloper = project.getCurrDeveloper();
+                this.currPlanner = project.getCurrPlanner();
+            }
+            case "S" -> {
+                Study study = (Study) post;
+
+                this.maxDesigner = study.getMaxMember();
+                this.currMember = study.getCurrMember();
+            }
+            case "M" -> {
+                Mentoring mentoring = (Mentoring) post;
+
+                this.maxMentor = mentoring.getMaxMentor();
+                this.maxMentee = mentoring.getCurrMentee();
+
+                this.currMentor = mentoring.getCurrMentor();
+                this.currMentee = mentoring.getCurrMentee();
+            }
+        }
+    }
 
     //Todo: isCompleted를 반환할 것인지 상의 -> 반환 한다면 tag 형식으로 표시하면 좋을 것 같음.
 }

--- a/src/main/java/com/hcu/hot6/repository/MemberRepository.java
+++ b/src/main/java/com/hcu/hot6/repository/MemberRepository.java
@@ -23,7 +23,7 @@ public class MemberRepository {
     }
 
     @Transactional
-    public void register(Member info) {
+    public void save(Member info) {
         em.persist(info);
     }
 

--- a/src/main/java/com/hcu/hot6/security/SecurityConfig.java
+++ b/src/main/java/com/hcu/hot6/security/SecurityConfig.java
@@ -75,9 +75,9 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
 
-        config.setAllowedOrigins(List.of("*"));
+        config.setAllowedOrigins(List.of(client));
         config.setAllowedMethods(Arrays.asList("POST", "GET", "PUT", "DELETE"));
-        config.setAllowedHeaders(List.of(HttpHeaders.AUTHORIZATION));
+        config.setAllowedHeaders(Arrays.asList(HttpHeaders.AUTHORIZATION, HttpHeaders.CONTENT_TYPE));
         config.setAllowCredentials(true);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/src/main/java/com/hcu/hot6/service/MemberService.java
+++ b/src/main/java/com/hcu/hot6/service/MemberService.java
@@ -1,0 +1,25 @@
+package com.hcu.hot6.service;
+
+import com.hcu.hot6.domain.Member;
+import com.hcu.hot6.domain.request.MemberRequest;
+import com.hcu.hot6.domain.response.MemberResponse;
+import com.hcu.hot6.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public MemberResponse updateMember(String email, MemberRequest form) {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow();
+        member.update(form);
+
+        return new MemberResponse(member);
+    }
+}

--- a/src/test/java/com/hcu/hot6/PostApiTest.java
+++ b/src/test/java/com/hcu/hot6/PostApiTest.java
@@ -75,7 +75,7 @@ public class PostApiTest {
                 .pictureUrl("picture")
                 .build();
 
-        memberRepository.register(member);
+        memberRepository.save(member);
     }
 
     // ==== CREATE ==== //

--- a/src/test/java/com/hcu/hot6/controller/MemberControllerTest.java
+++ b/src/test/java/com/hcu/hot6/controller/MemberControllerTest.java
@@ -1,0 +1,146 @@
+package com.hcu.hot6.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hcu.hot6.domain.Member;
+import com.hcu.hot6.domain.request.MemberRequest;
+import com.hcu.hot6.domain.response.MemberResponse;
+import com.hcu.hot6.repository.MemberRepository;
+import com.hcu.hot6.service.MemberService;
+import jakarta.annotation.PostConstruct;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MemberController.class)
+class MemberControllerTest {
+
+    private final static String TEST_EMAIL = "test@exmaple.com";
+
+    @Autowired
+    WebApplicationContext context;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockBean
+    MemberRepository memberRepository;
+
+    @MockBean
+    MemberService memberService;
+
+    MockMvc mvc;
+
+    @BeforeEach
+    public void setup() {
+        mvc = MockMvcBuilders
+                .webAppContextSetup(context)
+                .apply(springSecurity())
+                .build();
+    }
+
+    @PostConstruct
+    void memberSetup() {
+        Member member = Member.builder()
+                .uid("1")
+                .email(TEST_EMAIL)
+                .pictureUrl("picture")
+                .build();
+
+        memberRepository.save(member);
+    }
+
+    @Test
+    public void 프로필_생성_유효한_요청시() throws Exception {
+        // given
+        MemberRequest form = MemberRequest.builder()
+                .nickname("username")
+                .isPublic(Boolean.FALSE)
+                .build();
+
+        given(memberService.updateMember(anyString(), any()))
+                .willReturn(MemberResponse.builder()
+                        .nickname(form.getNickname())
+                        .isPublic(form.getIsPublic())
+                        .build());
+
+        // when
+        MvcResult mvcResult = mvc
+                .perform(post("/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(form))
+                        .with(oauth2Login()
+                                .attributes(attr -> attr
+                                        .put("sub", TEST_EMAIL)))
+                        .with(csrf()))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn();
+        // then
+        MemberResponse result =
+                objectMapper.readValue(mvcResult.getResponse()
+                        .getContentAsString(), MemberResponse.class);
+
+        assertThat(result.getNickname()).isEqualTo("username");
+        assertThat(result.getIsPublic()).isEqualTo(false);
+    }
+
+    @Test
+    public void 프로필_생성_필수정보_누락_닉네임() throws Exception {
+        // given
+        MemberRequest form = MemberRequest.builder()
+                // .nickname("username")
+                .isPublic(false)
+                .build();
+
+        // when
+        mvc
+                .perform(post("/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(form))
+                        .with(oauth2Login()
+                                .attributes(attr -> attr
+                                        .put("sub", TEST_EMAIL)))
+                        .with(csrf())
+                ).andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void 프로필_생성_필수정보_프로필_공개여부() throws Exception {
+        // given
+        MemberRequest form = MemberRequest.builder()
+                .nickname("username")
+                // .isPublic(false)
+                .build();
+
+        // when
+        mvc
+                .perform(post("/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(form))
+                        .with(oauth2Login()
+                                .attributes(attr -> attr
+                                        .put("sub", TEST_EMAIL)))
+                        .with(csrf())
+                ).andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+}


### PR DESCRIPTION
## Summary
- CORS: "Content-Type" 헤더 추가 허용
- 유저 관련 API: 프로필 생성, 조회

resolved: #54 #55 #59