### PR TITLE
유저 프로필 관련 API 개발

### DIFF
--- a/src/main/java/com/hcu/hot6/controller/MemberController.java
+++ b/src/main/java/com/hcu/hot6/controller/MemberController.java
@@ -12,10 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.*;
 
 @Controller
 @RequiredArgsConstructor
@@ -44,5 +41,10 @@ public class MemberController {
                                                                @RequestBody @Valid MemberRequest form) {
         Member member = memberService.updateMember(user.getName(), form);
         return ResponseEntity.ok(new MemberProfileResponse(member));
+    }
+
+    @DeleteMapping("/users/me")
+    public ResponseEntity<String> deleteAccount(@AuthenticationPrincipal OAuth2User user) {
+        return ResponseEntity.ok(memberService.deleteMember(user.getName()));
     }
 }

--- a/src/main/java/com/hcu/hot6/controller/MemberController.java
+++ b/src/main/java/com/hcu/hot6/controller/MemberController.java
@@ -14,6 +14,7 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Controller
@@ -27,17 +28,21 @@ public class MemberController {
     @PostMapping("/users")
     public ResponseEntity<MemberResponse> registerMember(@AuthenticationPrincipal OAuth2User user,
                                                          @RequestBody @Valid MemberRequest form) {
-        String email = user.getName();
-        MemberResponse response = memberService.updateMember(email, form);
-
-        return ResponseEntity.ok(response);
+        Member member = memberService.updateMember(user.getName(), form);
+        return ResponseEntity.ok(new MemberResponse(member));
     }
 
     @GetMapping("/users/me")
     public ResponseEntity<MemberProfileResponse> getProfile(@AuthenticationPrincipal OAuth2User user) {
         Member member = memberRepository.findByEmail(user.getName())
                 .orElseThrow();
+        return ResponseEntity.ok(new MemberProfileResponse(member));
+    }
 
+    @PutMapping("/users/me")
+    public ResponseEntity<MemberProfileResponse> modifyProfile(@AuthenticationPrincipal OAuth2User user,
+                                                               @RequestBody @Valid MemberRequest form) {
+        Member member = memberService.updateMember(user.getName(), form);
         return ResponseEntity.ok(new MemberProfileResponse(member));
     }
 }

--- a/src/main/java/com/hcu/hot6/domain/request/MemberRequest.java
+++ b/src/main/java/com/hcu/hot6/domain/request/MemberRequest.java
@@ -5,12 +5,9 @@ import com.hcu.hot6.domain.Position;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-import java.util.ArrayList;
 import java.util.List;
 
-@RequiredArgsConstructor
 @Builder
 @Getter
 public class MemberRequest {
@@ -21,11 +18,11 @@ public class MemberRequest {
     private final Boolean isPublic;
 
     private final String bio;
-    private final Department department = Department.NONE;
-    private final Position position = Position.NONE;
+    private final Department department;
+    private final Position position;
     private final Integer grade;
     private final String contact;
-    private final List<String> club = new ArrayList<>();
-    private final List<String> externalLinks = new ArrayList<>();
+    private final List<String> club;
+    private final List<String> externalLinks;
 
 }

--- a/src/main/java/com/hcu/hot6/repository/MemberRepository.java
+++ b/src/main/java/com/hcu/hot6/repository/MemberRepository.java
@@ -27,6 +27,11 @@ public class MemberRepository {
         em.persist(info);
     }
 
+    public String remove(Member info) {
+        em.remove(info);
+        return info.getEmail();
+    }
+
     public Optional<Member> findByEmail(String email) {
         return em.createQuery("select m from Member m where email = :email", Member.class)
                 .setParameter("email", email)

--- a/src/main/java/com/hcu/hot6/security/SecurityConfig.java
+++ b/src/main/java/com/hcu/hot6/security/SecurityConfig.java
@@ -116,7 +116,7 @@ public class SecurityConfig {
 
             if (registered.isEmpty()) {
                 Member member = new Member(oAuth2User.getAttributes());
-                memberRepository.register(member);
+                memberRepository.save(member);
             }
             return oAuth2User;
         };

--- a/src/main/java/com/hcu/hot6/service/MemberService.java
+++ b/src/main/java/com/hcu/hot6/service/MemberService.java
@@ -2,7 +2,6 @@ package com.hcu.hot6.service;
 
 import com.hcu.hot6.domain.Member;
 import com.hcu.hot6.domain.request.MemberRequest;
-import com.hcu.hot6.domain.response.MemberResponse;
 import com.hcu.hot6.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,11 +14,11 @@ public class MemberService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public MemberResponse updateMember(String email, MemberRequest form) {
+    public Member updateMember(String email, MemberRequest form) {
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow();
         member.update(form);
 
-        return new MemberResponse(member);
+        return member;
     }
 }

--- a/src/main/java/com/hcu/hot6/service/MemberService.java
+++ b/src/main/java/com/hcu/hot6/service/MemberService.java
@@ -7,6 +7,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 public class MemberService {
@@ -20,5 +22,14 @@ public class MemberService {
         member.update(form);
 
         return member;
+    }
+
+    @Transactional
+    public String deleteMember(String email) {
+        Optional<Member> member = memberRepository.findByEmail(email);
+
+        return (member.isPresent())
+                ? memberRepository.remove(member.get())
+                : "";
     }
 }

--- a/src/test/java/com/hcu/hot6/controller/MemberControllerTest.java
+++ b/src/test/java/com/hcu/hot6/controller/MemberControllerTest.java
@@ -307,4 +307,25 @@ class MemberControllerTest {
         assertThat(res.getNickname()).isEqualTo("modified");
         assertThat(res.getIsPublic()).isEqualTo(false);
     }
+
+    @Test
+    public void 프로필_삭제() throws Exception {
+        // given
+        given(memberService.deleteMember(anyString()))
+                .willReturn(TEST_EMAIL);
+
+        // when
+        MvcResult mvcResult = mvc
+                .perform(delete("/users/me")
+                        .with(oauth2Login()
+                                .attributes(attr -> attr
+                                        .put("sub", TEST_EMAIL)))
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andReturn();
+        // then
+        assertThat(mvcResult.getResponse()
+                .getContentAsString()).isEqualTo(TEST_EMAIL);
+    }
 }

--- a/src/test/java/com/hcu/hot6/controller/MemberControllerTest.java
+++ b/src/test/java/com/hcu/hot6/controller/MemberControllerTest.java
@@ -31,8 +31,7 @@ import static org.mockito.Mockito.anyString;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -83,7 +82,7 @@ class MemberControllerTest {
                 .build();
 
         given(memberService.updateMember(anyString(), any()))
-                .willReturn(MemberResponse.builder()
+                .willReturn(Member.ByMemberBuilder()
                         .nickname(form.getNickname())
                         .isPublic(form.getIsPublic())
                         .build());
@@ -245,5 +244,67 @@ class MemberControllerTest {
 
         assertThat(res.getPosts().size()).isEqualTo(1);
         assertThat(res.getPosts().get(0).getMaxDeveloper()).isEqualTo(3);
+    }
+
+    @Test
+    public void 프로필_수정() throws Exception {
+        // given
+        MemberRequest form = MemberRequest.builder()
+                .nickname("modified")
+                .isPublic(false)
+                .build();
+
+        given(memberService.updateMember(anyString(), any()))
+                .willReturn(Member.ByMemberBuilder()
+                        .email(TEST_EMAIL)
+                        .nickname("modified")
+                        .isPublic(false)
+                        .bio("bio")
+                        .grade(1)
+                        .contact("contact")
+                        .department(Department.CSEE)
+                        .position(Position.DEVELOPER)
+                        .club("club")
+                        .externalLinks("link")
+                        .posts(List.of(Project.builder()
+                                .dtype("P")
+                                .title("title")
+                                .content("content")
+                                .contact("contact")
+                                .author(Member.builder()
+                                        .uid("1")
+                                        .email(TEST_EMAIL)
+                                        .pictureUrl("picture")
+                                        .build())
+                                .period(Period.ByPeriodBuilder()
+                                        .postEnd(LocalDateTime.of(2023, 3, 2, 0, 0, 0))
+                                        .projectStart(LocalDateTime.of(2023, 3, 10, 0, 0, 0))
+                                        .projectEnd(LocalDateTime.of(2023, 7, 2, 0, 0, 0))
+                                        .build())
+                                .maxDeveloper(3)
+                                .maxDesigner(1)
+                                .build()))
+                        .likes(new ArrayList<>())
+                        .build());
+
+        // when
+        MvcResult mvcResult = mvc
+                .perform(put("/users/me")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(form))
+                        .with(oauth2Login()
+                                .attributes(attr -> attr
+                                        .put("sub", TEST_EMAIL)))
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andReturn();
+
+        MemberProfileResponse res = objectMapper.readValue(mvcResult.getResponse()
+                .getContentAsString(), MemberProfileResponse.class);
+
+        // then
+        assertThat(res.getNickname()).isEqualTo("modified");
+        assertThat(res.getIsPublic()).isEqualTo(false);
     }
 }


### PR DESCRIPTION
## Summary
- [x] 유저 프로필 생성
- [x] 유저 프로필 조회
- [x] 유저 프로필 수정
- [x] 유저 프로필 삭제

## Note
현재 `유저 프로필 생성` 은 메서드만 다를 뿐 내부적으로 프로필 업데이트 기능을 이용하는데, OAuth2 최초 로그인 과정에서 기본적인 정보를 저장하기 때문이다.

만약 OAuth2 최초 로그인 이후 닉네임과 부가정보를 입력 받을때까지 유저 등록을 지연시키고자 한다면 OAuth2 로그인 이후 프론트로 리다이렉트될 때 `uid`, `email` 과 같은 정보도 `query string`에 포함시켜야 할 것 같다.