### PR TITLE
:bug: [#59] 인가되지 않은 유저의 요청에 대해 401 에러 응답

### DIFF
--- a/src/main/java/com/hcu/hot6/security/SecurityConfig.java
+++ b/src/main/java/com/hcu/hot6/security/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.hcu.hot6.domain.Member;
 import com.hcu.hot6.filter.JwtAuthorizationFilter;
 import com.hcu.hot6.repository.MemberRepository;
 import com.hcu.hot6.service.JwtService;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -19,11 +20,12 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
-import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter;
 import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.DefaultRedirectStrategy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -51,23 +53,22 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .cors(Customizer.withDefaults())
-                .sessionManagement()
-                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-                .and()
                 .csrf().disable()
                 .formLogin().disable()
                 .httpBasic().disable()
                 .authorizeHttpRequests(authz -> authz
                         .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
-                        .requestMatchers("/login", "/oauth2/*").permitAll()
                         .requestMatchers(HttpMethod.GET, "/posts**").permitAll()
                         .anyRequest().authenticated())
-                .addFilterBefore(this.jwtAuthorizationFilter(), OAuth2LoginAuthenticationFilter.class)
                 .oauth2Login(oauth2 -> oauth2
                         .userInfoEndpoint(userInfo -> userInfo
                                 .userService(this.oAuth2UserService()))
-                        .successHandler(this.oAuth2SuccessHandler())
-                );
+                        .successHandler(this.oAuth2SuccessHandler()))
+                .addFilterBefore(this.jwtAuthorizationFilter(), UsernamePasswordAuthenticationFilter.class)
+                .sessionManagement(config -> config
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(handler -> handler
+                        .authenticationEntryPoint(this.oAuth2AuthenticationEntryPoint()));
         return http.build();
     }
 
@@ -88,6 +89,11 @@ public class SecurityConfig {
     @Bean
     public JwtAuthorizationFilter jwtAuthorizationFilter() {
         return new JwtAuthorizationFilter(jwtService);
+    }
+
+    private AuthenticationEntryPoint oAuth2AuthenticationEntryPoint() {
+        return (request, response, authException) ->
+                response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
     }
 
     private AuthenticationSuccessHandler oAuth2SuccessHandler() {


### PR DESCRIPTION
## Summary
![jwt_invalid_v2](https://user-images.githubusercontent.com/45687157/220101960-7fd31ae6-35a5-4253-8a26-57da30c862f0.png)

## Note
프론트에서 API 호출후 401 에러 응답시 로그인 화면으로 이동하는 `handler` 구현 필요함.
