### PR TITLE
인재풀 조회 API 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,10 @@ dependencies {
     implementation 'org.jetbrains:annotations:23.0.0'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/hcu/hot6/config/QueryDSLConfig.java
+++ b/src/main/java/com/hcu/hot6/config/QueryDSLConfig.java
@@ -1,4 +1,4 @@
-package com.hcu.hot6.security;
+package com.hcu.hot6.config;
 
 import com.querydsl.jpa.impl.JPAQuery;
 import jakarta.persistence.EntityManager;

--- a/src/main/java/com/hcu/hot6/config/SecurityConfig.java
+++ b/src/main/java/com/hcu/hot6/config/SecurityConfig.java
@@ -1,4 +1,4 @@
-package com.hcu.hot6.security;
+package com.hcu.hot6.config;
 
 import com.hcu.hot6.domain.Member;
 import com.hcu.hot6.filter.JwtAuthorizationFilter;

--- a/src/main/java/com/hcu/hot6/controller/MemberController.java
+++ b/src/main/java/com/hcu/hot6/controller/MemberController.java
@@ -1,6 +1,9 @@
 package com.hcu.hot6.controller;
 
+import com.hcu.hot6.domain.Department;
 import com.hcu.hot6.domain.Member;
+import com.hcu.hot6.domain.Position;
+import com.hcu.hot6.domain.filter.PoolSearchFilter;
 import com.hcu.hot6.domain.request.MemberRequest;
 import com.hcu.hot6.domain.response.MemberProfileResponse;
 import com.hcu.hot6.domain.response.MemberResponse;
@@ -8,11 +11,15 @@ import com.hcu.hot6.repository.MemberRepository;
 import com.hcu.hot6.service.MemberService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Controller
 @RequiredArgsConstructor
@@ -46,5 +53,31 @@ public class MemberController {
     @DeleteMapping("/users/me")
     public ResponseEntity<String> deleteAccount(@AuthenticationPrincipal OAuth2User user) {
         return ResponseEntity.ok(memberService.deleteMember(user.getName()));
+    }
+
+    @GetMapping("/pool")
+    public ResponseEntity<List<MemberProfileResponse>> getProfiles(@AuthenticationPrincipal OAuth2User user,
+                                                                   @RequestParam int page,
+                                                                   @RequestParam(required = false) Department department,
+                                                                   @RequestParam(required = false) Position position,
+                                                                   @RequestParam(required = false) String grade) {
+
+        Member member = memberRepository.findByEmail(user.getName())
+                .orElseThrow();
+
+        if (member.isPublic()) {
+            PoolSearchFilter filter = PoolSearchFilter.builder()
+                    .page(page)
+                    .department(department)
+                    .position(position)
+                    .grade(grade)
+                    .build();
+
+            return ResponseEntity.ok(memberService.getMatchedProfilesWith(filter)
+                    .stream()
+                    .map(MemberProfileResponse::new)
+                    .collect(Collectors.toList()));
+        }
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED.value()).build();
     }
 }

--- a/src/main/java/com/hcu/hot6/domain/Pagination.java
+++ b/src/main/java/com/hcu/hot6/domain/Pagination.java
@@ -1,0 +1,31 @@
+package com.hcu.hot6.domain;
+
+import lombok.Getter;
+
+import static java.lang.Math.min;
+
+@Getter
+public class Pagination {
+    public final static long LIMIT = 12;
+    private final static int PAGE_OFFSET = 5;
+
+    public Pagination(int page, Long total) {
+        this.curr = page;
+        this.total = total;
+        this.pageEnd = min(
+                (int) (Math.ceil((double) curr / PAGE_OFFSET) * PAGE_OFFSET),
+                (int) Math.ceil((double) total / LIMIT)
+        );
+        this.pageBegin = pageEnd - (PAGE_OFFSET - 1);
+        this.offset = (page - 1) * LIMIT;
+    }
+
+    private final int curr;
+    private final Long total;
+
+    private final int pageBegin;
+    private final int pageEnd;
+
+    private final long offset;
+
+}

--- a/src/main/java/com/hcu/hot6/domain/filter/PoolSearchFilter.java
+++ b/src/main/java/com/hcu/hot6/domain/filter/PoolSearchFilter.java
@@ -1,0 +1,15 @@
+package com.hcu.hot6.domain.filter;
+
+import com.hcu.hot6.domain.Department;
+import com.hcu.hot6.domain.Position;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class PoolSearchFilter {
+    private int page;
+    private Department department;
+    private Position position;
+    private String grade;
+}

--- a/src/main/java/com/hcu/hot6/repository/PoolRepository.java
+++ b/src/main/java/com/hcu/hot6/repository/PoolRepository.java
@@ -1,0 +1,55 @@
+package com.hcu.hot6.repository;
+
+import com.hcu.hot6.domain.*;
+import com.hcu.hot6.domain.filter.PoolSearchFilter;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class PoolRepository {
+    private final JPAQuery<Member> query;
+    private final QMember qMember = QMember.member;
+
+    public List<Member> matchWith(PoolSearchFilter filter, long offset) {
+        return query.select(qMember)
+                .from(qMember)
+                .where(
+                        eqDepartment(filter.getDepartment()),
+                        eqPosition(filter.getPosition()),
+                        eqGrade(filter.getGrade())
+                ).limit(Pagination.LIMIT)
+                .offset(offset)
+                .orderBy(NumberExpression.random().asc())
+                .fetch();
+    }
+
+    public Long count(PoolSearchFilter filter) {
+        return query.select(qMember.count())
+                .from(qMember)
+                .where(
+                        eqDepartment(filter.getDepartment()),
+                        eqPosition(filter.getPosition()),
+                        eqGrade(filter.getGrade())
+                ).fetchOne();
+    }
+
+    private BooleanExpression eqDepartment(Department department) {
+        return (department == null) ? null : qMember.department.eq(department);
+    }
+
+    private BooleanExpression eqPosition(Position position) {
+        return (position == null) ? null : qMember.position.eq(position);
+    }
+
+    private BooleanExpression eqGrade(String grade) {
+        return (StringUtils.hasText(grade)) ? qMember.grade.eq(grade) : null;
+    }
+
+}

--- a/src/main/java/com/hcu/hot6/security/QueryDSLConfig.java
+++ b/src/main/java/com/hcu/hot6/security/QueryDSLConfig.java
@@ -1,0 +1,19 @@
+package com.hcu.hot6.security;
+
+import com.querydsl.jpa.impl.JPAQuery;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDSLConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQuery<?> jpaQuery() {
+        return new JPAQuery<Void>(entityManager);
+    }
+}

--- a/src/main/java/com/hcu/hot6/service/MemberService.java
+++ b/src/main/java/com/hcu/hot6/service/MemberService.java
@@ -1,21 +1,26 @@
 package com.hcu.hot6.service;
 
 import com.hcu.hot6.domain.Member;
+import com.hcu.hot6.domain.Pagination;
+import com.hcu.hot6.domain.filter.PoolSearchFilter;
 import com.hcu.hot6.domain.request.MemberRequest;
 import com.hcu.hot6.repository.MemberRepository;
+import com.hcu.hot6.repository.PoolRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final PoolRepository poolRepository;
 
-    @Transactional
     public Member updateMember(String email, MemberRequest form) {
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow();
@@ -24,12 +29,16 @@ public class MemberService {
         return member;
     }
 
-    @Transactional
     public String deleteMember(String email) {
         Optional<Member> member = memberRepository.findByEmail(email);
 
         return (member.isPresent())
                 ? memberRepository.remove(member.get())
                 : "";
+    }
+
+    public List<Member> getMatchedProfilesWith(PoolSearchFilter filter) {
+        long offset = new Pagination(filter.getPage(), poolRepository.count(filter)).getOffset();
+        return poolRepository.matchWith(filter, offset);
     }
 }

--- a/src/test/java/com/hcu/hot6/repository/PoolRepositoryTest.java
+++ b/src/test/java/com/hcu/hot6/repository/PoolRepositoryTest.java
@@ -1,0 +1,109 @@
+package com.hcu.hot6.repository;
+
+import com.hcu.hot6.domain.Department;
+import com.hcu.hot6.domain.Member;
+import com.hcu.hot6.domain.Position;
+import com.hcu.hot6.domain.filter.PoolSearchFilter;
+import com.hcu.hot6.domain.request.MemberRequest;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@Transactional
+@SpringBootTest
+class PoolRepositoryTest {
+
+    @PersistenceContext
+    EntityManager em;
+
+    @Autowired
+    PoolRepository poolRepository;
+
+    private final static String TEST_EMAIL = "test@example.com";
+
+    @Test
+    void 모든_필터에_해당하는_결과_개수_일치() {
+        PoolSearchFilter filter = PoolSearchFilter.builder()
+                .page(1)
+                .department(Department.전산전자공학부)
+                .position(Position.개발자)
+                .grade("1")
+                .build();
+
+        for (int i = 0; i < 100; ++i) {
+            Member member = Member.builder()
+                    .uid("uid")
+                    .pictureUrl("pictureUrl")
+                    .email(TEST_EMAIL)
+                    .build();
+
+            member.update(MemberRequest.builder()
+                    .nickname("username")
+                    .department(Department.전산전자공학부)
+                    .position(Position.개발자)
+                    .grade("1")
+                    .isPublic(true)
+                    .build());
+            em.persist(member);
+        }
+        assertThat(poolRepository.count(filter)).isEqualTo(100);
+    }
+
+    @Test
+    public void 검색_필터에_해당하는_데이터_조회() throws Exception {
+        // given
+        PoolSearchFilter filter = PoolSearchFilter.builder()
+                .page(1)
+                .department(Department.전산전자공학부)
+                .position(Position.개발자)
+                .grade("1")
+                .build();
+        Random random = new Random();
+        // when
+        for (int i = 0; i < 3; ++i) {
+            Member member = Member.builder()
+                    .uid("uid")
+                    .pictureUrl("pictureUrl")
+                    .email(TEST_EMAIL)
+                    .build();
+
+            member.update(MemberRequest.builder()
+                    .nickname("username")
+                    .department(Department.전산전자공학부)
+                    .position(Position.개발자)
+                    .g드rade("1")
+                    .isPublic(true)
+                    .build());
+            em.persist(member);
+        }
+
+        for (int i = 0; i < 9; ++i) {
+            Member member = Member.builder()
+                    .uid("uid")
+                    .pictureUrl("pictureUrl")
+                    .email(TEST_EMAIL)
+                    .build();
+
+            member.update(MemberRequest.builder()
+                    .nickname("username")
+                    .department(Department.전산전자공학부)
+                    .position(Position.개발자)
+                    .grade("2")
+                    .isPublic(true)
+                    .build());
+            em.persist(member);
+        }
+        // then
+        assertThat(poolRepository.matchWith(filter, 0)).hasSize(3);
+    }
+}


### PR DESCRIPTION
## Summary
- [x] 필터링 적용: `QueryDSL` 사용하여 동적 쿼리 사용 - 학부, 직군(포지션), 학년
- [x] 페이징 처리: 한 번에 12개, 최대 5페이지까지 표시

resolved: #75 