### PR TITLE
컨버터 삭제 롤백

### DIFF
--- a/src/main/java/com/hcu/hot6/domain/Position.java
+++ b/src/main/java/com/hcu/hot6/domain/Position.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.RequiredArgsConstructor;
 
+import java.util.Arrays;
+
 @RequiredArgsConstructor
 public enum Position {
     ORDINARY("일반"),
@@ -14,8 +16,11 @@ public enum Position {
     private final String name;
 
     @JsonCreator
-    public static Department from(String json) {
-        return Department.valueOf(json);
+    public static Department from(String property) {
+        return Arrays.stream(Department.values())
+                .filter(value -> value.getName().equals(property))
+                .findFirst()
+                .orElseThrow();
     }
 
     @JsonValue

--- a/src/main/java/com/hcu/hot6/domain/converter/DepartmentConverter.java
+++ b/src/main/java/com/hcu/hot6/domain/converter/DepartmentConverter.java
@@ -1,0 +1,19 @@
+package com.hcu.hot6.domain.converter;
+
+import com.hcu.hot6.domain.Department;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DepartmentConverter implements Converter<String, Department> {
+
+    @Override
+    public Department convert(String source) {
+        for (Department department : Department.values()) {
+            if (department.getName().equals(source)) {
+                return department;
+            }
+        }
+        throw new IllegalArgumentException("No match found: source = " + source);
+    }
+}

--- a/src/main/java/com/hcu/hot6/domain/converter/PositionConverter.java
+++ b/src/main/java/com/hcu/hot6/domain/converter/PositionConverter.java
@@ -1,0 +1,19 @@
+package com.hcu.hot6.domain.converter;
+
+import com.hcu.hot6.domain.Position;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PositionConverter implements Converter<String, Position> {
+
+    @Override
+    public Position convert(String source) {
+        for (Position position : Position.values()) {
+            if (position.getName().equals(source)) {
+                return position;
+            }
+        }
+        throw new IllegalArgumentException("No match found: source = " + source);
+    }
+}


### PR DESCRIPTION
## Summary
- `@RequestParam` 을 통해 query string 을 enum class 에 매핑할 때 사용하는 컨버터 롤백.
- `Position` 관련 deserialization 코드 추가