### PR TITLE
스터디 모집글 인원 관련 버그 수정

### DIFF
--- a/src/main/java/com/hcu/hot6/domain/response/PostReadOneResponse.java
+++ b/src/main/java/com/hcu/hot6/domain/response/PostReadOneResponse.java
@@ -70,7 +70,7 @@ public class PostReadOneResponse {
             case "S" -> {
                 Study study = (Study) post;
 
-                this.maxDesigner = study.getMaxMember();
+                this.maxMember = study.getMaxMember();
                 this.currMember = study.getCurrMember();
             }
             case "M" -> {


### PR DESCRIPTION
- 스터디 모집글을 조회하고 응답하는 과정에서 `maxMember` 값이 제대로 반영되지 않는 문제 발생
- `maxDesigner` -> `maxMember` 수정