### PR TITLE
로그인 상태 확인 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    implementation 'org.mariadb.jdbc:mariadb-java-client:3.1.2'
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"

--- a/src/main/java/com/hcu/hot6/controller/AuthController.java
+++ b/src/main/java/com/hcu/hot6/controller/AuthController.java
@@ -1,0 +1,16 @@
+package com.hcu.hot6.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class AuthController {
+
+    @GetMapping("/auth")
+    public ResponseEntity<String> authorize(@AuthenticationPrincipal OAuth2User user) {
+        return ResponseEntity.ok(user.getName());
+    }
+}

--- a/src/main/java/com/hcu/hot6/controller/PostApiController.java
+++ b/src/main/java/com/hcu/hot6/controller/PostApiController.java
@@ -1,4 +1,4 @@
-package com.hcu.hot6;
+package com.hcu.hot6.controller;
 
 import com.hcu.hot6.domain.enums.OrderBy;
 import com.hcu.hot6.domain.enums.PostType;

--- a/src/main/java/com/hcu/hot6/domain/request/PostCreationRequest.java
+++ b/src/main/java/com/hcu/hot6/domain/request/PostCreationRequest.java
@@ -1,13 +1,11 @@
 package com.hcu.hot6.domain.request;
 
-import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 import lombok.Builder;
 import lombok.Data;
 import org.springframework.format.annotation.DateTimeFormat;
 
-import java.time.LocalDateTime;
 import java.util.Date;
 
 @Data
@@ -36,14 +34,12 @@ public class PostCreationRequest {
     private int maxDesigner;
 
     @DateTimeFormat(pattern = "yyyy-MM-dd")
-    @Future
     @NotNull
     private Date postEnd;
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     @NotNull
     private Date projectStart;
     @DateTimeFormat(pattern = "yyyy-MM-dd")
-    @Future
     @NotNull
     private Date projectEnd;
 

--- a/src/main/java/com/hcu/hot6/domain/response/MemberPoolResponse.java
+++ b/src/main/java/com/hcu/hot6/domain/response/MemberPoolResponse.java
@@ -1,6 +1,5 @@
 package com.hcu.hot6.domain.response;
 
-import com.hcu.hot6.domain.Member;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -11,5 +10,5 @@ import java.util.List;
 public class MemberPoolResponse {
 
     private final long total;
-    private final List<Member> members;
+    private final List<MemberProfileResponse> members;
 }

--- a/src/main/java/com/hcu/hot6/repository/PoolRepository.java
+++ b/src/main/java/com/hcu/hot6/repository/PoolRepository.java
@@ -22,7 +22,8 @@ public class PoolRepository {
                 .where(
                         eqDepartment(filter.getDepartment()),
                         eqPosition(filter.getPosition()),
-                        eqGrade(filter.getGrade())
+                        eqGrade(filter.getGrade()),
+                        qMember.isPublic
                 ).limit(Pagination.LIMIT)
                 .offset(offset)
                 .orderBy(NumberExpression.random().asc())
@@ -35,7 +36,8 @@ public class PoolRepository {
                 .where(
                         eqDepartment(filter.getDepartment()),
                         eqPosition(filter.getPosition()),
-                        eqGrade(filter.getGrade())
+                        eqGrade(filter.getGrade()),
+                        qMember.isPublic
                 ).fetchOne();
     }
 

--- a/src/main/java/com/hcu/hot6/service/MemberService.java
+++ b/src/main/java/com/hcu/hot6/service/MemberService.java
@@ -5,6 +5,7 @@ import com.hcu.hot6.domain.Pagination;
 import com.hcu.hot6.domain.filter.PoolSearchFilter;
 import com.hcu.hot6.domain.request.MemberRequest;
 import com.hcu.hot6.domain.response.MemberPoolResponse;
+import com.hcu.hot6.domain.response.MemberProfileResponse;
 import com.hcu.hot6.repository.MemberRepository;
 import com.hcu.hot6.repository.PoolRepository;
 import lombok.RequiredArgsConstructor;
@@ -39,7 +40,10 @@ public class MemberService {
 
     public MemberPoolResponse getMatchedProfilesWith(PoolSearchFilter filter) {
         var pagination = new Pagination(filter.getPage(), poolRepository.count(filter));
-        var members = poolRepository.matchWith(filter, pagination.getOffset());
+        var members = poolRepository.matchWith(filter, pagination.getOffset())
+                .stream()
+                .map(MemberProfileResponse::new)
+                .toList();
 
         return new MemberPoolResponse(pagination.getTotal(), members);
     }

--- a/src/test/java/com/hcu/hot6/PostApiTest.java
+++ b/src/test/java/com/hcu/hot6/PostApiTest.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hcu.hot6.domain.Member;
 import com.hcu.hot6.domain.request.MemberRequest;
 import com.hcu.hot6.domain.request.PostCreationRequest;
-import com.hcu.hot6.domain.response.MemberResponse;
 import com.hcu.hot6.domain.response.PostCreationResponse;
 import com.hcu.hot6.domain.response.PostReadOneResponse;
 import com.hcu.hot6.repository.MemberRepository;
@@ -13,13 +12,11 @@ import jakarta.annotation.PostConstruct;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -27,7 +24,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
-import java.util.List;
+import java.util.Date;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
@@ -42,7 +39,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * 기타
  * - Post Create 시, LocalDateTime에 실제 날짜의 범위를 넘어선 값이 들어오는 경우에 대해서는 Validation 어노테이션 필요 없음 -> 자바에서 LocalDateTime으로 변환하는 과정에서 Validation 체크
  */
-@ExtendWith(SpringExtension.class)
 @SpringBootTest
 @AutoConfigureMockMvc
 public class PostApiTest {
@@ -113,9 +109,9 @@ public class PostApiTest {
                 .title("title")
                 .content("content")
                 .contact("contact")
-                .postEnd(java.sql.Timestamp.valueOf(LocalDateTime.of(2023, 3, 2, 0, 0, 0)))
-                .projectStart(java.sql.Timestamp.valueOf(LocalDateTime.of(2023, 3, 10, 0, 0, 0)))
-                .projectEnd(java.sql.Timestamp.valueOf(LocalDateTime.of(2023, 7, 2, 0, 0, 0)))
+                .postEnd(new Date())
+                .projectStart(new Date())
+                .projectEnd(new Date())
                 .maxMentor(1)
                 .maxMentee(2)
                 .build();
@@ -162,35 +158,6 @@ public class PostApiTest {
                 .postEnd(java.sql.Timestamp.valueOf(LocalDateTime.of(2023, 3, 2, 0, 0, 0)))
                 .projectStart(java.sql.Timestamp.valueOf(LocalDateTime.of(2023, 3, 10, 0, 0, 0)))
                 .projectEnd(java.sql.Timestamp.valueOf(LocalDateTime.of(2023, 7, 2, 0, 0, 0)))
-                .maxMentor(1)
-                .maxMentee(2)
-                .build();
-
-        mockMvc
-                .perform(post("/posts")
-                        .contentType("application/json")
-                        .content(objectMapper.writeValueAsString(request))
-                        .with(oauth2Login()
-                                .attributes(attr -> attr
-                                        .put("sub", TEST_EMAIL))))
-                .andExpect(status().isBadRequest())
-                .andDo(print());
-    }
-
-    /**
-     * Validation 체크 2번 항목
-     */
-    @DisplayName("모집글 유효 검사: 과거 날짜 입력 여부")
-    @Test
-    public void 날짜입력_Future() throws Exception {
-        PostCreationRequest request = PostCreationRequest.builder()
-                .dtype("M")
-                .title("title")
-                .content("content")
-                .contact("contact")
-                .postEnd(java.sql.Timestamp.valueOf(LocalDateTime.of(2023, 3, 2, 0, 0, 0)))
-                .projectStart(java.sql.Timestamp.valueOf(LocalDateTime.of(2023, 3, 10, 0, 0, 0)))
-                .projectEnd(java.sql.Timestamp.valueOf(LocalDateTime.of(2022, 7, 2, 0, 0, 0)))
                 .maxMentor(1)
                 .maxMentee(2)
                 .build();
@@ -379,7 +346,7 @@ public class PostApiTest {
     @Test
     public void 찜_추가() throws Exception {
         // given
-        postService.createPost(PostCreationRequest.builder()
+        var post = postService.createPost(PostCreationRequest.builder()
                 .dtype("M")
                 .title("title")
                 .content("content")
@@ -393,7 +360,7 @@ public class PostApiTest {
 
         // when
         MvcResult mvcResult = mockMvc
-                .perform(post("/posts/{postId}/likes", 1)
+                .perform(post("/posts/{postId}/likes", post.getId())
                         .with(oauth2Login()
                                 .attributes(attr -> attr
                                         .put("sub", "lifeIsGood@test.com"))))
@@ -402,17 +369,16 @@ public class PostApiTest {
                 .andReturn();
 
         // then
-        List<MemberResponse> results = List.of(objectMapper.readValue(mvcResult.getResponse()
-                .getContentAsString(), MemberResponse[].class));
+        PostReadOneResponse results = objectMapper.readValue(mvcResult.getResponse()
+                .getContentAsString(), PostReadOneResponse.class);
 
-        assertThat(results.size()).isEqualTo(1);
-        assertThat(results.get(0).getNickname()).isEqualTo("member2");
+        assertThat(results.getNLiked()).isEqualTo(1);
     }
 
     @Test
     public void 찜_삭제() throws Exception {
         // given
-        postService.createPost(PostCreationRequest.builder()
+        var post = postService.createPost(PostCreationRequest.builder()
                 .dtype("M")
                 .title("title")
                 .content("content")
@@ -424,11 +390,11 @@ public class PostApiTest {
                 .maxMentee(2)
                 .build(), TEST_EMAIL);
 
-        postService.addBookmark(1L, "lifeIsGood@test.com");
+        postService.addBookmark(post.getId(), "lifeIsGood@test.com");
 
         // when
         MvcResult mvcResult = mockMvc
-                .perform(delete("/posts/{postId}/likes", 1)
+                .perform(delete("/posts/{postId}/likes", post.getId())
                         .with(oauth2Login()
                                 .attributes(attr -> attr
                                         .put("sub", "lifeIsGood@test.com"))))
@@ -437,9 +403,9 @@ public class PostApiTest {
                 .andReturn();
 
         // then
-        List<MemberResponse> results = List.of(objectMapper.readValue(mvcResult.getResponse()
-                .getContentAsString(), MemberResponse[].class));
+        PostReadOneResponse results = objectMapper.readValue(mvcResult.getResponse()
+                .getContentAsString(), PostReadOneResponse.class);
 
-        assertThat(results.size()).isEqualTo(0);
+        assertThat(results.getNLiked()).isEqualTo(0);
     }
 }

--- a/src/test/java/com/hcu/hot6/controller/AuthControllerTest.java
+++ b/src/test/java/com/hcu/hot6/controller/AuthControllerTest.java
@@ -1,0 +1,73 @@
+package com.hcu.hot6.controller;
+
+import com.hcu.hot6.domain.Member;
+import com.hcu.hot6.repository.MemberRepository;
+import jakarta.annotation.PostConstruct;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class AuthControllerTest {
+
+    private static final String TEST_EMAIL = "test@example.com";
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    public void setup() {
+        mockMvc = MockMvcBuilders
+                .webAppContextSetup(context)
+                .apply(springSecurity())
+                .build();
+    }
+
+    @PostConstruct
+    void memberSetup() {
+        Member member1 = Member.builder()
+                .uid("1")
+                .email(TEST_EMAIL)
+                .pictureUrl("picture")
+                .build();
+
+        memberRepository.save(member1);
+    }
+
+    @Test
+    public void 인증_확인_홈페이지() throws Exception {
+        // when
+        MvcResult mvcResult = mockMvc
+                .perform(get("/auth")
+                        .with(oauth2Login()
+                                .attributes(attr -> attr
+                                        .put("sub", TEST_EMAIL))))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn();
+
+        // then
+        String res = mvcResult.getResponse().getContentAsString();
+        assertThat(res).isEqualTo(TEST_EMAIL);
+    }
+
+}

--- a/src/test/java/com/hcu/hot6/controller/PostControllerTest.java
+++ b/src/test/java/com/hcu/hot6/controller/PostControllerTest.java
@@ -1,4 +1,4 @@
-package com.hcu.hot6;
+package com.hcu.hot6.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hcu.hot6.domain.Member;
@@ -42,7 +42,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  */
 @SpringBootTest
 @AutoConfigureMockMvc
-public class PostApiTest {
+public class PostControllerTest {
 
     private static final String TEST_EMAIL = "test@example.com";
 


### PR DESCRIPTION
## Summary
- 모집글 페이지에서 모집글 작성 페이지 이동시 서버를 거치지 않아 로그인 상태와 관계없이 작성폼으로 이동하는 이슈가 있었음.
- 홈페이지, 모집글 페이지, 모집글 상세, 모집글 작성페이지에서 로그인 상태를 확인하기 위한 API 를 추가로 요청하여 토큰이 만료되었는지 검증하고 로그인 상태를 업데이트 하고자 함.

- 200 OK 응답시 토큰 유효
- 401 Unauthorized 응답시 토큰 만료(또는 유효하지 않음)