### PR TITLE
:bug: 인재풀 목록을 임의로 불러오지 못하는 버그 수정

### DIFF
--- a/src/main/java/com/hcu/hot6/repository/PoolRepository.java
+++ b/src/main/java/com/hcu/hot6/repository/PoolRepository.java
@@ -3,7 +3,7 @@ package com.hcu.hot6.repository;
 import com.hcu.hot6.domain.*;
 import com.hcu.hot6.domain.filter.PoolSearchFilter;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -26,7 +26,7 @@ public class PoolRepository {
                         qMember.isPublic
                 ).limit(Pagination.LIMIT)
                 .offset(offset)
-                .orderBy(NumberExpression.random().asc())
+                .orderBy(Expressions.numberTemplate(Double.class, "function('rand')").asc())
                 .fetch();
     }
 


### PR DESCRIPTION
## 문제 분석

이 에러는 `mariadb` 를 사용하는 `prod` 환경에서 로그인 후 인재풀 페이지에 접속 했을 때 보고 되었다.

```
Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed: org.springframework.dao.InvalidDataAccessResourceUsageException: JDBC exception executing SQL [select m1_0.id,m1_0.bio,m1_0.club,m1_0.contact,m1_0.department,m1_0.email,m1_0.external_links,m1_0.grade,m1_0.is_public,m1_0.is_registered,m1_0.nickname,m1_0.picture_url,m1_0.position,m1_0.uid from member m1_0 where m1_0.is_public order by random() asc limit ?,?]; SQL [n/a]] with root cause

java.sql.SQLSyntaxErrorException: (conn=10402) FUNCTION dner_api.random does not exist

…

at com.hcu.hot6.repository.PoolRepository.matchWith(PoolRepository.java:30) ~[main/:na]

```

에러 메시지를 살펴보면, `PoolRepository` 클래스의 `matchWith` 메서드 내에 구현된 쿼리를 실행하는 과정에서 예외가 발생했다 (`JDBC exception executing SQL`**)**. 예외의 유형은 `SQLSyntaxErrorException` 으로 사용된 SQL 문법이 유효하지 않음을 의미한다. 메서드 내에 구현된 쿼리는 아래와 같이 `QueryDSL` 문법을 사용했으며 `mariadb` 환경에서 `random` 이라는 함수를 인식하지 못하는 것으로 보인다.

```java
public List<Member> matchWith(PoolSearchFilter filter, long offset) {
        return query.selectFrom(qMember)
                .where(
		// ...
                ).limit(Pagination.LIMIT)
                .offset(offset)
                .orderBy(NumberExpression.random().asc()) // exception here
                .fetch();
    }
```

## 해결방안

예외가 발생한 코드 `.orderBy(NumberExpression.random().asc())` 의 의도는 레코드를 랜덤으로 정렬하여 조회하기 위함이었다. 따라서 `orderBy()` 안의 들어가는 `argument` 를 의도한 범위 내에서 유효하게 바꿔주어야 한다. 이미 비슷한 사례가 보고되었다.

[https://github.com/querydsl/querydsl/issues/1881](https://github.com/querydsl/querydsl/issues/1881)