### PR TITLE
:ambulance: 예약어와 중복 피하기 위해 좋아요 관련 엔티티명 변경

### DIFF
--- a/src/main/java/com/hcu/hot6/domain/Likes.java
+++ b/src/main/java/com/hcu/hot6/domain/Likes.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Like {
+public class Likes {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/hcu/hot6/domain/Member.java
+++ b/src/main/java/com/hcu/hot6/domain/Member.java
@@ -45,7 +45,7 @@ public class Member {
     private boolean isRegistered = true;
 
     @OneToMany(mappedBy = "member")
-    private List<Like> likes = new ArrayList<>();
+    private List<Likes> likes = new ArrayList<>();
 
     @OneToMany(mappedBy = "author", orphanRemoval = true)
     private List<Post> posts = new ArrayList<>();

--- a/src/main/java/com/hcu/hot6/domain/Post.java
+++ b/src/main/java/com/hcu/hot6/domain/Post.java
@@ -40,7 +40,7 @@ public class Post {
     private String targetDepartment;    // 다중선택 가능. "," 콤마로 구분
 
     @OneToMany(mappedBy = "post")
-    private List<Like> likes = new ArrayList<>();
+    private List<Likes> likes = new ArrayList<>();
 
     @OneToMany(mappedBy = "post")
     private List<Position> positions = new ArrayList<>();

--- a/src/main/java/com/hcu/hot6/service/KeywordService.java
+++ b/src/main/java/com/hcu/hot6/service/KeywordService.java
@@ -4,6 +4,7 @@ import com.hcu.hot6.domain.Keyword;
 import com.hcu.hot6.repository.KeywordRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -11,6 +12,7 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class KeywordService {
 
     private final KeywordRepository keywordRepository;


### PR DESCRIPTION
`like` 키워드를 사용하는 쿼리에서 예약어 중복으로 인한 오류 보고.

변경 전 : `Like`
변경 후:  `Likes`