### PR TITLE
모집마감일이 변경이 안되는 버그 수정 

### DIFF
--- a/src/main/java/com/hcu/hot6/domain/Thumbnail.java
+++ b/src/main/java/com/hcu/hot6/domain/Thumbnail.java
@@ -13,6 +13,7 @@ import java.time.LocalDateTime;
 import java.util.Date;
 
 import static com.hcu.hot6.util.Utils.nonNullOrElse;
+import static com.hcu.hot6.util.Utils.toLocalDateTime;
 
 @Getter
 @Entity
@@ -62,11 +63,11 @@ public class Thumbnail {
         this.tags = (req.getTags() != null) ? req.getTags().combine() : tags;
         this.summary = nonNullOrElse(req.getSummary(), summary);
         this.recruitStart = nonNullOrElse(Utils.toLocalDateTime(req.getRecruitStart()), recruitStart);
-        this.recruitEnd = nonNullOrElse(Utils.toLocalDateTime(req.getRecruitEnd()), recruitEnd);
+        this.recruitEnd = toLocalDateTime(req.getRecruitEnd());
         this.duration = nonNullOrElse(req.getDuration(), duration);
         this.isClosed = nonNullOrElse(req.getIsClosed(), isClosed);
 
-        if(req.getRecruitEnd() != null && req.getRecruitEnd().after(new Date())) this.isClosed = false;
+        if (req.getRecruitEnd() != null && req.getRecruitEnd().after(new Date())) this.isClosed = false;
     }
 
     public void close() {

--- a/src/test/java/com/hcu/hot6/post/PostReadTests.java
+++ b/src/test/java/com/hcu/hot6/post/PostReadTests.java
@@ -278,4 +278,22 @@ public class PostReadTests {
         // then
         assertThat(res.getDuration()).isEqualTo("봄학기 ~ 여름방학");
     }
+
+    @Test
+    public void 모집글_마감기간_미설정() throws Exception {
+        // given
+        var req = PostCreationRequest.builder()
+                .title("제목")
+                .recruitStart(new Date())
+                .recruitEnd(null)
+                .build();
+
+        // when
+        var post = postService.createPost(req, TEST_EMAIL);
+        var res = postService.readOnePost(post.getId(), TEST_EMAIL);
+
+        // then
+        assertThat(res.getTitle()).isEqualTo("제목");
+        assertThat(res.getRecruitEnd()).isNull();
+    }
 }

--- a/src/test/java/com/hcu/hot6/post/PostUpdateTests.java
+++ b/src/test/java/com/hcu/hot6/post/PostUpdateTests.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
+
 import java.util.Date;
 import java.util.List;
 
@@ -88,7 +89,7 @@ public class PostUpdateTests {
     }
 
     @Test
-    public void 모집마감일_수정_자동재오픈() throws Exception{
+    public void 모집마감일_수정_자동재오픈() throws Exception {
         // given
         final var req = PostCreationRequest.builder()
                 .title("모집글 제목")
@@ -123,5 +124,49 @@ public class PostUpdateTests {
 
         // then
         assertThat(res2.isClosed()).isEqualTo(false);
+    }
+
+    @Test
+    public void 모집마감일_설정에서_미설정으로() throws Exception {
+        // given
+        var req = PostCreationRequest.builder()
+                .title("제목")
+                .recruitStart(new Date())
+                .recruitEnd(new Date())
+                .build();
+        var post = postService.createPost(req, TEST_EMAIL);
+
+        // when
+        var form = PostUpdateRequest.builder()
+                .recruitEnd(null)
+                .build();
+        var pid = postService.updatePost(post.getId(), form).getId();
+        var res = postService.readOnePost(pid, TEST_EMAIL);
+
+        // then
+        assertThat(res.getTitle()).isEqualTo("제목");
+        assertThat(res.getRecruitEnd()).isNull();
+    }
+
+    @Test
+    public void 모집마감일_미설정에서_설정으로() throws Exception {
+        // given
+        var req = PostCreationRequest.builder()
+                .title("제목")
+                .recruitStart(new Date())
+                .recruitEnd(null)
+                .build();
+        var post = postService.createPost(req, TEST_EMAIL);
+
+        // when
+        var form = PostUpdateRequest.builder()
+                .recruitEnd(new Date())
+                .build();
+        var pid = postService.updatePost(post.getId(), form).getId();
+        var res = postService.readOnePost(pid, TEST_EMAIL);
+
+        // then
+        assertThat(res.getTitle()).isEqualTo("제목");
+        assertThat(res.getRecruitEnd()).isNotNull();
     }
 }


### PR DESCRIPTION
모집마감일이 미설정(상시모집)된 글에 대해 마감이 변경이 안되는 이슈가 있었음.

모집글 수정시 변경사항이 있는 필드에 대해서만 값을 보내도록 요청했기 때문에,

`null` 이 아닌 값에 대해서만 값을 업데이트하도록 설정했는데 상시모집에 대한 값도 `null`이기 때문에 이를 구분할 수 없는 문제가 발생했음.

따라서 `모집마감일` 필드의 경우에만 값 변경 여부와 관계 없이 보내도록 함.

마감일이 1970년으로 표기되는 것은 `null`로 응답된 모집마감일에 대한 처리가 1970년으로 된 것으로 보임. 

closed: #236